### PR TITLE
fix(util): Fix logging of string exceptions

### DIFF
--- a/src/util.ts
+++ b/src/util.ts
@@ -276,7 +276,12 @@ export class Logger {
     }
 
     if (exception) {
-      Logger.error(exception.stack);
+      if (typeof exception === 'string') {
+        Logger.error(exception);
+      } 
+      if (exception.stack) {
+        Logger.error(exception.stack);
+      }
     }
 
     return false;


### PR DESCRIPTION
When an exception is a plain string nothing is printed. This change will log string exceptions, and will also only log stack if it exists.

In my case the build was not correctly clearing the .tmp folder and throwing a string error that looked like: "tmpDir error: Error: ENOTEMPTY: directory not empty, rmdir"