### PR TITLE
fix(rollup): add globals and defaults plugins

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -3,6 +3,7 @@ var nodeResolve = require('rollup-plugin-node-resolve');
 var commonjs = require('rollup-plugin-commonjs');
 var globals = require('rollup-plugin-node-globals');
 var builtins = require('rollup-plugin-node-builtins');
+var json = require('rollup-plugin-json');
 
 // https://github.com/rollup/rollup/wiki/JavaScript-API
 
@@ -36,6 +37,7 @@ var rollupConfig = {
    */
   plugins: [
     ngTemplate(),
+    builtins(),
     commonjs(),
     nodeResolve({
       module: true,
@@ -45,7 +47,7 @@ var rollupConfig = {
       extensions: ['.js']
     }),
     globals(),
-    builtins()
+    json()
   ]
 
 };

--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -1,6 +1,8 @@
 var ngTemplate = require('../dist/plugins/ng-template').ngTemplate;
 var nodeResolve = require('rollup-plugin-node-resolve');
 var commonjs = require('rollup-plugin-commonjs');
+var globals = require('rollup-plugin-node-globals');
+var builtins = require('rollup-plugin-node-builtins');
 
 // https://github.com/rollup/rollup/wiki/JavaScript-API
 
@@ -41,7 +43,9 @@ var rollupConfig = {
       main: true,
       browser: true,
       extensions: ['.js']
-    })
+    }),
+    globals(),
+    builtins()
   ]
 
 };

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "postcss": "5.2.0",
     "rollup": "0.36.1",
     "rollup-plugin-commonjs": "5.0.4",
+    "rollup-plugin-json": "2.0.2",
     "rollup-plugin-node-builtins": "1.2.1",
     "rollup-plugin-node-globals": "1.0.9",
     "rollup-plugin-node-resolve": "2.0.0",

--- a/package.json
+++ b/package.json
@@ -33,6 +33,8 @@
     "postcss": "5.2.0",
     "rollup": "0.36.1",
     "rollup-plugin-commonjs": "5.0.4",
+    "rollup-plugin-node-builtins": "1.2.1",
+    "rollup-plugin-node-globals": "1.0.9",
     "rollup-plugin-node-resolve": "2.0.0",
     "rollup-pluginutils": "1.5.2",
     "tslint": "3.15.1",


### PR DESCRIPTION
This is needed for libraries which use built in node methods such as PouchDB. These plugins have no effect on libs which do not use these methods. Without this added a user will have to add these plugins themselves which is not ideal in my opinion.