### PR TITLE
Make sure all watcher updates respect user specific configs

### DIFF
--- a/src/copy.ts
+++ b/src/copy.ts
@@ -20,7 +20,7 @@ export function copy(context?: BuildContext, copyConfig?: CopyConfig) {
 export function copyUpdate(event: string, path: string, context: BuildContext, options: BuildOptions) {
   Logger.debug(`copyUpdate, event: ${event}, path: ${path}`);
 
-  const copyConfig = fillConfigDefaults(context, {}, COPY_TASK_INFO);
+  const copyConfig = fillConfigDefaults(context, null, COPY_TASK_INFO);
   return runCopy(context, copyConfig);
 }
 

--- a/src/ngc.ts
+++ b/src/ngc.ts
@@ -30,7 +30,7 @@ export function ngc(context?: BuildContext, options?: BuildOptions, ngcConfig?: 
 export function ngcUpdate(event: string, path: string, context: BuildContext, options: BuildOptions) {
   Logger.debug(`ngcUpdate, event: ${event}, path: ${path}`);
 
-  const ngcConfig = fillConfigDefaults(context, {}, NGC_TASK_INFO);
+  const ngcConfig = fillConfigDefaults(context, null, NGC_TASK_INFO);
   return runNgc(context, options, ngcConfig);
 }
 

--- a/src/sass.ts
+++ b/src/sass.ts
@@ -58,7 +58,7 @@ export function sass(context?: BuildContext, options?: BuildOptions, sassConfig?
 export function sassUpdate(event: string, path: string, context: BuildContext, options: BuildOptions, useCache: boolean = false) {
   Logger.debug(`sassUpdate, event: ${event}, path: ${path}`);
 
-  const sassConfig = fillConfigDefaults(context, {}, SASS_TASK_INFO);
+  const sassConfig = fillConfigDefaults(context, null, SASS_TASK_INFO);
   return sass(context, options, sassConfig, useCache);
 }
 

--- a/src/spec/util.spec.ts
+++ b/src/spec/util.spec.ts
@@ -90,6 +90,42 @@ describe('util', () => {
       expect(config).not.toBe(configStub);
     });
 
+    it('should load config when null is passed for config object', () => {
+      const configFilePath = `dummyConfigFilePath`;
+      const requiredModules: string[] = [];
+      const config: any = null;
+
+      addArgv('-s');
+      addArgv(configFilePath);
+      spyOn(require('module'), '_load').and
+        .callFake((moduleName: string) => {
+          requiredModules.push(moduleName);
+          return {};
+        });
+
+      fillConfigDefaults({ rootDir: './' }, config, { fullArgConfig: '', shortArgConfig: '-s', defaultConfigFilename: '', envConfig: '' });
+
+      expect(requiredModules).toContain(configFilePath);
+    });
+
+    it('should not load config when empty object is passed for config object', () => {
+      const configFilePath = `dummyConfigFilePath`;
+      const requiredModules: string[] = [];
+      const config = {};
+
+      addArgv('-s');
+      addArgv(configFilePath);
+      spyOn(require('module'), '_load').and
+        .callFake((moduleName: string) => {
+          requiredModules.push(moduleName);
+          return {};
+        });
+
+      fillConfigDefaults({ rootDir: './' }, config, { fullArgConfig: '', shortArgConfig: '-s', defaultConfigFilename: '', envConfig: '' });
+
+      expect(requiredModules).not.toContain(configFilePath);
+    });
+
   });
 
   let context: BuildContext;


### PR DESCRIPTION
#### Short description of what this resolves:


#### Changes proposed in this pull request:

-
-
-

**Fixes**: #

Because watch is called in various places with an empty object, fillConfigDefaults will not load user specified defaults and just apply the defaults.