### PR TITLE
fix(copy): fixes #78

### DIFF
--- a/src/copy.ts
+++ b/src/copy.ts
@@ -45,7 +45,8 @@ function copySrcToDest(context: BuildContext, src: string, dest: string, filter?
   src = replacePathVars(context, src);
   dest = replacePathVars(context, dest);
   const opts = {
-    filter: filter
+    filter: filter,
+    clobber: false
   };
 
   return new Promise((resolve: any, reject: any) => {


### PR DESCRIPTION
#### Short description of what this resolves:
Copy no longer overwrites a directory when it is written too. This allows the use case of someone setting up a custom copy.config that copies two seperate src directories to the same destination directory.

#### Changes proposed in this pull request:

- add the [clobber](https://github.com/jprichardson/node-fs-extra#copy) option and set it to false

**Fixes**: #78

