### PR TITLE
Support path mapping

### DIFF
--- a/config/ngc.config.js
+++ b/config/ngc.config.js
@@ -1,6 +1,8 @@
 
 module.exports = {
-
+  compilerOptions: {
+    baseUrl: '.'
+  },
   include: [
     './**/*.d.ts',
     './app/app.module.ts',

--- a/src/ngc.ts
+++ b/src/ngc.ts
@@ -125,6 +125,9 @@ function createTmpTsConfig(context: BuildContext, ngcConfig: NgcConfig) {
   // force where to look for ts files
   tsConfig.include = ngcConfig.include;
 
+  // change baseUrl to support path mappings
+  tsConfig.compilerOptions.baseUrl = ngcConfig.compilerOptions.baseUrl;
+  
   // save the modified copy into the tmp directory
   outputJsonSync(getTmpTsConfigPath(context), tsConfig);
 }

--- a/src/ngc.ts
+++ b/src/ngc.ts
@@ -6,7 +6,6 @@ import { endsWith } from './util/helpers';
 import { Logger } from './util/logger';
 import { getTsConfig } from './transpile';
 
-
 export function ngc(context?: BuildContext, options?: BuildOptions, ngcConfig?: NgcConfig) {
   context = generateContext(context);
   options = generateBuildOptions(options);
@@ -127,7 +126,7 @@ function createTmpTsConfig(context: BuildContext, ngcConfig: NgcConfig) {
 
   // change baseUrl to support path mappings
   tsConfig.compilerOptions.baseUrl = ngcConfig.compilerOptions.baseUrl;
-  
+
   // save the modified copy into the tmp directory
   outputJsonSync(getTmpTsConfigPath(context), tsConfig);
 }
@@ -195,4 +194,7 @@ const NGC_TASK_INFO: TaskInfo = {
 
 export interface NgcConfig {
   include: string[];
+  compilerOptions: {
+    baseUrl: string;
+  };
 }

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -191,6 +191,7 @@ export interface TsCompilerOptions {
   outDir: string;
   removeComments: boolean;
   target: string;
+  baseUrl: string;
 }
 
 const ION_COMPILER_COMMENT = '/* ion-compiler */';


### PR DESCRIPTION
#### Short description of what this resolves:

Add support of path mapping in ngc step of build
#### Changes proposed in this pull request:
- Add compilerOptions.baseUrl to conf/ngc.config.js
- Replace compilerOptions.baseUrl from above config in tsconfig.json copied during ngc step of build to .tmp directory

**Fixes**: #125
