### PR TITLE
adding ability for rollup plugins to be placed before ion compiler

### DIFF
--- a/src/bundle.ts
+++ b/src/bundle.ts
@@ -75,6 +75,12 @@ function runRollup(context: BuildContext, options: BuildOptions, rollupConfig: R
     rollupConfig.plugins.unshift(
       ionCompiler(context, options)
     );
+
+    // add plugins that need to run before ion-compiler
+    if (rollupConfig.prependPlugins) {
+      rollupConfig.plugins.unshift(...rollupConfig.prependPlugins);
+      delete rollupConfig.prependPlugins;
+    }
   }
 
   if (useCache) {
@@ -227,6 +233,9 @@ export interface RollupConfig {
   dest?: string;
   cache?: RollupBundle;
   onwarn?: Function;
+
+  // augmentation; used by ionic-app-scripts only
+  prependPlugins?: any[];
 }
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
Currently it's not possible have rollup plugins run before the ion compiler plugin. This is sometimes necessary, such as to inline styleUrls as styles using rollup-angular-plugin.

#### Changes proposed in this pull request:
The proposed changes allow an optional `prependPlugins` property to be defined on the rollup config. These plugins are prepended to the rollup plugins, after the ion compiler, if `prependPlugins` exists.
