### PR TITLE
chore(config): always generate sourcemap unless user config doesn't w…

### DIFF
--- a/config/rollup.config.js
+++ b/config/rollup.config.js
@@ -55,7 +55,6 @@ var rollupConfig = {
 if (process.env.IONIC_ENV == 'prod') {
   // production mode
   rollupConfig.entry = '{{TMP}}/app/main.prod.ts';
-  rollupConfig.sourceMap = false;
 }
 
 


### PR DESCRIPTION
Always generate source maps. If a particular user does not want them generated for distribution, they can A) remove them or B) configure their app with a custom config so it doesn't generate them.

Thanks,
Dan