### PR TITLE
fix(package): homepage typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@ionic/app-scripts",
   "version": "0.0.30",
   "description": "Scripts for Ionic Projects",
-  "homepage": "http//ionicframework.com/",
+  "homepage": "http://ionicframework.com/",
   "author": "Ionic Team <hi@ionic.io> (http://ionic.io)",
   "license": "MIT",
   "files": [


### PR DESCRIPTION
#### Short description of what this resolves:
When checking if there was a nightly available on npm, I spotted the following `homepage` property when running `npm view @ionic/app-scripts`:
```js
homepage: 'http://http//ionicframework.com/'
```

#### Changes proposed in this pull request:

- Fix the typo in `package.json`