### PR TITLE
fix(): fixes issue #73

### DIFF
--- a/config/copy.config.js
+++ b/config/copy.config.js
@@ -30,5 +30,6 @@ module.exports = {
     {
       src: 'node_modules/ionic-angular/fonts/',
       dest: '{{WWW}}/assets/fonts/'
+    }
   ]
 };

--- a/config/copy.config.js
+++ b/config/copy.config.js
@@ -24,7 +24,7 @@ module.exports = {
       dest: '{{BUILD}}/polyfills.js'
     },
     {
-      src: 'node_modules/ionicons/dist/fonts/',
+      src: 'node_modules/ionic-angular/fonts/',
       dest: '{{WWW}}/assets/fonts/'
     },
   ]

--- a/config/copy.config.js
+++ b/config/copy.config.js
@@ -24,8 +24,11 @@ module.exports = {
       dest: '{{BUILD}}/polyfills.js'
     },
     {
-      src: 'node_modules/ionic-angular/fonts/',
+      src: 'node_modules/ionicons/dist/fonts/',
       dest: '{{WWW}}/assets/fonts/'
     },
+    {
+      src: 'node_modules/ionic-angular/fonts/',
+      dest: '{{WWW}}/assets/fonts/'
   ]
 };

--- a/config/sass.config.js
+++ b/config/sass.config.js
@@ -42,7 +42,8 @@ module.exports = {
    */
   includePaths: [
     'node_modules/ionic-angular/themes',
-    'node_modules/ionicons/dist/scss'
+    'node_modules/ionicons/dist/scss',
+    'node_modules/ionic-angular/fonts'
   ],
 
   /**

--- a/config/sass.config.js
+++ b/config/sass.config.js
@@ -42,7 +42,6 @@ module.exports = {
    */
   includePaths: [
     'node_modules/ionic-angular/themes',
-    'node_modules/ionicons/dist/scss',
     'node_modules/ionic-angular/fonts'
   ],
 

--- a/config/sass.config.js
+++ b/config/sass.config.js
@@ -42,6 +42,7 @@ module.exports = {
    */
   includePaths: [
     'node_modules/ionic-angular/themes',
+    'node_modules/ionicons/dist/scss',
     'node_modules/ionic-angular/fonts'
   ],
 


### PR DESCRIPTION
#### Short description of what this resolves:

This fixes the roboto and noto-sans fonts not getting included. The copy task did not copy over the fonts before and instead just copied over ionicons. It now copies over fonts and ionicons. This also changes the sass config to make sure it looks in the right directory.
#### Changes proposed in this pull request:
- Change copy.config to pull in all fonts instead of just ionicons
- Change sass.config to look in the right directory

**Fixes**: #73
