### PR TITLE
fix(transpile): use rootDir as destination

### DIFF
--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -57,7 +57,7 @@ export function transpileWorker(context: BuildContext, configFile: string) {
 
     // force it to save in the src directory
     // however, it's only in memory and won't actually write to disk
-    tsConfig.options.outDir = context.srcDir;
+    tsConfig.options.outDir = context.rootDir;
     tsConfig.options.sourceMap = buildJsSourceMaps(context);
     tsConfig.options.declaration = false;
     const tsFileNames = cleanFileNames(context, tsConfig.fileNames);


### PR DESCRIPTION
#### Short description of what this resolves:
See #160. This is probably just a quick fix, as the main problem seems to be that .ts files in the rootDir are transpiled while only the .ts files in the srcDir should be transpiled.

**Fixes**: #160