### PR TITLE
Fixes #164

### DIFF
--- a/src/rollup.ts
+++ b/src/rollup.ts
@@ -102,13 +102,13 @@ export function rollupWorker(context: BuildContext, configFile: string): Promise
       }).catch((err: any) => {
         // ensure references are cleared up when there's an error
         bundle = cachedBundle = rollupConfig = rollupConfig.cache = rollupConfig.onwarn = rollupConfig.plugins = null;
-        throw new BuildError(err);
+        reject(err);
       });
 
     }).catch((err: any) => {
       // ensure references are cleared up when there's an error
       cachedBundle = rollupConfig = rollupConfig.cache = rollupConfig.onwarn = rollupConfig.plugins = null;
-      throw new BuildError(err);
+      reject(err);
     });
   });
 }


### PR DESCRIPTION
Short description of what this resolves:

Rollup bundle errors will now be correctly passed on to catch handlers of whole build process and thus failing it when rollup error occurs. Previously they didn't make it to the catch handler.

Fixes: #164 