### PR TITLE
fix(webpack config): dev entry point

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -13,7 +13,7 @@ function getEntryPoint() {
   if (process.env.IONIC_ENV === 'prod') {
     return '{{TMP}}/app/main.prod.js';
   }
-  return '{{TMP}}/app/main.dev.js';
+  return '{{TMP}}/app/main.dev.ts';
 }
 
 function getPlugins() {


### PR DESCRIPTION
#### Short description of what this resolves:
Change the webpack dev entry to .ts rather than .js

**Fixes**: #269 269

