### PR TITLE
Fixed nullpointer in copy.ts 

### DIFF
--- a/src/copy.ts
+++ b/src/copy.ts
@@ -143,7 +143,7 @@ function copySrcToDest(context: BuildContext, src: string, dest: string, filter:
 
     fs.copy(src, dest, opts, (err) => {
       if (err) {
-        if (err.message.indexOf('ENOENT') > -1) {
+        if (err.message && err.message.indexOf('ENOENT') > -1) {
           resolve({ success: false, src: src, dest: dest, errorMessage: `Error copying "${src}" to "${dest}": File not found`});
         } else {
           resolve({ success: false, src: src, dest: dest, errorMessage: `Error copying "${src}" to "${dest}"`});


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes issue #305 - resolves the issue of getting a 'TypeError - can't find "indexOf" of undefined' while building the project.

#### Changes proposed in this pull request:

- Check err object to see if it has a "message" parameter before calling "indexOf" on that parameter. 

**Fixes**: #305 

A "TypeError - can't find "indexOf" of undefined" was being thrown in copySrcToDest function when a copy error was detected and its message was interpreted.