### PR TITLE
fix(webpack): resolve modules to rootDir

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -61,7 +61,8 @@ module.exports = {
   devtool: getDevtool(),
 
   resolve: {
-    extensions: ['.js', '.ts', '.json']
+    extensions: ['.js', '.ts', '.json'],
+    modules: [path.resolve('{{ROOT}}', 'node_modules')]
   },
 
   module: {


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes packages that are linked via `npm link`. See https://github.com/angular/angular-cli/pull/2291 for more details.

#### Changes proposed in this pull request:

- Added a `resolve.modules` property to webpack config to support linked modules.