### PR TITLE
feat(sass): add option to pass addition postcss plugins

### DIFF
--- a/src/sass.ts
+++ b/src/sass.ts
@@ -463,7 +463,7 @@ export interface SassConfig {
   sourceMap?: string;
   omitSourceMapUrl?: boolean;
   sourceMapContents?: boolean;
-  postCssPlugins: any[];
+  postCssPlugins?: any[];
 }
 
 

--- a/src/sass.ts
+++ b/src/sass.ts
@@ -274,7 +274,16 @@ function renderSassSuccess(context: BuildContext, sassResult: Result, sassConfig
 
     Logger.debug(`sass, start postcss/autoprefixer`);
 
-    return postcss([autoprefixer(sassConfig.autoprefixer)])
+    let postCssPlugins = [autoprefixer(sassConfig.autoprefixer)];
+
+    if (sassConfig.postCssPlugins) {
+      postCssPlugins = [
+        ...sassConfig.postCssPlugins,
+        ...postCssPlugins
+      ];
+    }
+
+    return postcss(postCssPlugins)
       .process(sassResult.css, postcssOptions).then((postCssResult: any) => {
         postCssResult.warnings().forEach((warn: any) => {
           Logger.warn(warn.toString());
@@ -446,7 +455,7 @@ export interface SassConfig {
   excludeModules?: string[];
   includeFiles?: RegExp[];
   excludeFiles?: RegExp[];
-  directoryMaps?: {[key: string]: string};
+  directoryMaps?: { [key: string]: string };
   sortComponentPathsFn?: (a: any, b: any) => number;
   sortComponentFilesFn?: (a: any, b: any) => number;
   variableSassFiles?: string[];
@@ -454,6 +463,7 @@ export interface SassConfig {
   sourceMap?: string;
   omitSourceMapUrl?: boolean;
   sourceMapContents?: boolean;
+  postCssPlugins: any[];
 }
 
 


### PR DESCRIPTION
#### Short description of what this resolves:
POstCss has a number of plugins, and it would be cool that user can provide their own plugin through config

```js
postCssPlugins: [
    require('precss') 
]
```