### PR TITLE
bugfix(buildUpdate): export BuildUpdate from watch rather than build

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-export { build, buildUpdate } from './build';
+export { build } from './build';
 export { bundle, bundleUpdate } from './bundle';
 export { clean } from './clean';
 export { cleancss } from './cleancss';
@@ -9,7 +9,7 @@ export { ngc } from './ngc';
 export { sass, sassUpdate } from './sass';
 export { transpile } from './transpile';
 export { uglifyjs } from './uglifyjs';
-export { watch } from './watch';
+export { watch, buildUpdate } from './watch';
 export * from './util/config';
 export * from './util/helpers';
 export * from './util/interfaces';


### PR DESCRIPTION
#### Short description of what this resolves:
Not quite sure if `buildUpdate` from build is required, but I assume the `watch`  `buildUpdate` can be used instead as it also offers denouncing. Although in the watch buildUpdate `js`  files are not handled but there is another `PR` for this https://github.com/driftyco/ionic-app-scripts/pull/375.

Would be nice if the tasks are wrapped in a module thus you can export the whole module add and consume them something like;

```js
const ionicScripts = require("@ionic/app-scripts");
ionicScripts.watch.buildUpdate(...);
```

or internally

```ts
import { watch } from "./watch";
watch.buildUpdate(...);

import { build } from "./build";
build.buildUpdate(...);
build.runBuildUpdate(...);
```

The above will also solve the issue that in different module/files the method names are called the same.


#### Changes proposed in this pull request:

- export BuildUpdate from watch rather than build

**Fixes**: #366