### PR TITLE
fix(proxies): Proxies list of ionic.config.json not loading

### DIFF
--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -46,7 +46,7 @@ function setupProxies(app: express.Application) {
       opts.rejectUnauthorized = !(proxy.rejectUnauthorized === false);
 
       app.use(proxy.path, proxyMiddleware(opts));
-      Logger.info('Proxy added:', proxy.path + ' => ' + url.format(opts));
+      Logger.info('Proxy added:' + proxy.path + ' => ' + url.format(opts));
     }
   });
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Proxies list of ionic.config.json not loading
Wrong parameter in Logger.info(), in setupProxies function stops proxies loading

**Fixes**: #346
