### PR TITLE
feat(lint): option to disable ts lint and process.exit(1) on error

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,6 +114,7 @@ npm run build --rollup ./config/rollup.config.js
 | src directory   | `ionic_src_dir`     | `--srcDir`    | `src`           | The directory holding the Ionic src code |
 | www directory   | `ionic_www_dir`     | `--wwwDir`    | `www`           | The deployable directory containing everything needed to run the app |
 | build directory | `ionic_build_dir`   | `--buildDir`  | `build`         | The build process uses this directory to store generated files, etc |
+| ts lint level   | `ionic_lint_Level`   | `--buildDir`  | `build`         | The build process uses this directory to store generated files, etc |
 
 
 ### Ionic Environment Variables
@@ -142,7 +143,7 @@ These tasks are available within `ionic-app-scripts` and can be added to NPM scr
 
 | Task       | Description                                                                                         |
 |------------|-----------------------------------------------------------------------------------------------------|
-| `build`    | Full production build. Use `--dev` flag for dev build.                                              |
+| `build`    | Full production build. Use `--dev` flag for dev build. Use `--noLint` to disable lint               |
 | `bundle`   | Bundle JS modules.                                                                                  |
 | `clean`    | Empty the `www` directory.                                                                          |
 | `cleancss` | Compress the output CSS with [CleanCss](https://github.com/jakubpawlowicz/clean-css)                |
@@ -152,7 +153,7 @@ These tasks are available within `ionic-app-scripts` and can be added to NPM scr
 | `ngc`      | Runs just the `ngc` portion of the production build.                                                |
 | `sass`     | Sass compilation of used modules. Bundling must have as least ran once before Sass compilation.     |
 | `transpile`| Runs just the `tsc` portion of the dev build.                                                       |
-| `watch`    | Runs watch for dev builds.                                                                          |
+| `watch`    | Runs watch for dev builds. Use `--noLint` to disable lint.                                          |
 
 Example NPM Script:
 

--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ npm run build --rollup ./config/rollup.config.js
 | src directory   | `ionic_src_dir`     | `--srcDir`    | `src`           | The directory holding the Ionic src code |
 | www directory   | `ionic_www_dir`     | `--wwwDir`    | `www`           | The deployable directory containing everything needed to run the app |
 | build directory | `ionic_build_dir`   | `--buildDir`  | `build`         | The build process uses this directory to store generated files, etc |
-| ts lint level   | `ionic_lint_Level`   | `--buildDir`  | `build`         | The build process uses this directory to store generated files, etc |
+| lint level      | `ionic_lint_Level`  | `--lintLevel` | `warn`          | Lint message type for `prod` build either `error` or `warn`. When `error` process will exit with exitCode 1 when lint issue is found. |
 
 
 ### Ionic Environment Variables

--- a/src/build.ts
+++ b/src/build.ts
@@ -73,14 +73,15 @@ function buildProd(context: BuildContext) {
       ]);
     })
     .then(() => {
-      // kick off the tslint after everything else
-      // nothing needs to wait on its completion
-      lint(context);
-
       // ensure the async tasks have fully completed before resolving
       return Promise.all([
         copyPromise
       ]);
+    })
+    .then(() => {
+      // kick off the tslint after everything else
+      // nothing needs to wait on its completion
+      return lint(context);
     })
     .catch(err => {
       throw new BuildError(err);
@@ -112,8 +113,7 @@ function buildDev(context: BuildContext) {
     .then(() => {
       // kick off the tslint after everything else
       // nothing needs to wait on its completion
-      lint(context);
-      return Promise.resolve();
+      return lint(context);
     })
     .catch(err => {
       throw new BuildError(err);

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -17,7 +17,7 @@ export function lint(context?: BuildContext, configFile?: string) {
   context = generateContext(context)
 
   if (context.noLint) {
-    Logger.debug('Linter is disabled.');
+    Logger.debug('Lint is disabled.');
     return Promise.resolve();
   }
 
@@ -38,18 +38,13 @@ export function lintWorker(context: BuildContext, configFile: string) {
   });
 }
 
-
-<<<<<<< HEAD
-export function lintUpdate(event: string, filePath: string, context: BuildContext) {
+export function lintUpdate(changedFiles: ChangedFile[], context: BuildContext) {
   if (context.noLint) {
-    Logger.debug('Linter is disabled.');
+    Logger.debug('Lint is disabled.');
     return Promise.resolve();
   }
 
-=======
-export function lintUpdate(changedFiles: ChangedFile[], context: BuildContext) {
   const changedTypescriptFiles = changedFiles.filter(changedFile => changedFile.ext === '.ts');
->>>>>>> a674dafa8206e9a2e979740d6b5acb5bc283f2bb
   return new Promise(resolve => {
     // throw this in a promise for async fun, but don't let it hang anything up
     const workerConfig: LintWorkerConfig = {

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -31,7 +31,7 @@ export function lintWorker(context: BuildContext, configFile: string) {
   return getLintConfig(context, configFile).then(configFile => {
     // there's a valid tslint config, let's continue
     return lintApp(context, configFile);
-  }).catch(() => { });
+  }).catch(() => {});
 }
 
 

--- a/src/lint.ts
+++ b/src/lint.ts
@@ -35,7 +35,7 @@ export function lintWorker(context: BuildContext, configFile: string) {
   return getLintConfig(context, configFile).then(configFile => {
     // there's a valid tslint config, let's continue
     return lintApp(context, configFile);
-  })
+  });
 }
 
 

--- a/src/logger/logger-tslint.ts
+++ b/src/logger/logger-tslint.ts
@@ -15,7 +15,7 @@ function loadDiagnostic(context: BuildContext, f: RuleFailure) {
   const end: RuleFailurePosition = f.endPosition.toJson();
 
   const d: Diagnostic = {
-    level: 'warn',
+    level: context.isWatch ? 'warn' : context.lintLevel,
     type: 'tslint',
     language: 'typescript',
     absFileName: f.fileName,

--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -47,6 +47,9 @@ export function generateContext(context?: BuildContext): BuildContext {
   const sourceMapValue = getConfigValue(context, '--sourceMap', null, ENV_VAR_SOURCE_MAP, ENV_VAR_SOURCE_MAP.toLowerCase(), 'eval');
   setProcessEnvVar(ENV_VAR_SOURCE_MAP, sourceMapValue);
 
+  context.lintLevel = getConfigValue(context, '--lintLevel', null, ENV_VAR_LINT_LEVEL, ENV_VAR_LINT_LEVEL.toLowerCase(), 'warn');
+  setProcessEnvVar(ENV_VAR_LINT_LEVEL, context.lintLevel);
+
   if (!isValidBundler(context.bundler)) {
     context.bundler = bundlerStrategy(context);
   }
@@ -56,6 +59,10 @@ export function generateContext(context?: BuildContext): BuildContext {
 
   if (typeof context.isWatch !== 'boolean') {
     context.isWatch = hasArg('--watch');
+  }
+  
+  if (typeof context.noLint !== 'boolean') {
+    context.noLint = hasArg('--noLint');
   }
 
   context.inlineTemplates = true;
@@ -390,6 +397,7 @@ const ENV_VAR_WWW_DIR = 'IONIC_WWW_DIR';
 const ENV_VAR_BUILD_DIR = 'IONIC_BUILD_DIR';
 const ENV_VAR_APP_SCRIPTS_DIR = 'IONIC_APP_SCRIPTS_DIR';
 const ENV_VAR_SOURCE_MAP = 'IONIC_SOURCE_MAP';
+const ENV_VAR_LINT_LEVEL = 'IONIC_LINT_LEVEL';
 
 export const BUNDLER_ROLLUP = 'rollup';
 export const BUNDLER_WEBPACK = 'webpack';

--- a/src/util/interfaces.ts
+++ b/src/util/interfaces.ts
@@ -21,6 +21,9 @@ export interface BuildContext {
   transpileState?: BuildState;
   templateState?: BuildState;
   bundleState?: BuildState;
+
+  noLint?: boolean;
+  lintLevel?: 'warn' | 'error';
 }
 
 

--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -24,6 +24,7 @@ export function runWorker(taskModule: string, taskWorker: string, context: Build
         isWatch: context.isWatch,
         bundler: context.bundler,
         inlineTemplates: context.inlineTemplates,
+        lintLevel: context.lintLevel
       },
       workerConfig
     };


### PR DESCRIPTION
#### Short description of what this resolves:
Add 2 options, one to disable TS lint when running a command and secondly to fail a CI build with process.exit(1);

#### Changes proposed in this pull request:

- Add flag to disable ts lint
- Add config option to exit process with error code 1


More info in the read me file

**Fixes**: #223 #287 

