### PR TITLE
Use localhost instead of 0.0.0.0 when injecting live reload script

### DIFF
--- a/src/dev-server/live-reload.ts
+++ b/src/dev-server/live-reload.ts
@@ -53,6 +53,9 @@ export function injectLiveReloadScript(content: any, host: string, port: Number)
 }
 
 function getLiveReloadScript(host: string, port: Number) {
+  if (host === '0.0.0.0') {
+    host = 'localhost';
+  }
   var src = `//${host}:${port}/livereload.js?snipver=1`;
   return `  <!-- Ionic Dev Server: Injected LiveReload Script -->\n  <script src="${src}" async="" defer=""></script>`;
 }


### PR DESCRIPTION
#### Short description of what this resolves:
When the dev server listens on 0.0.0.0, it injects a live reload script that looks like this: `<script src="//0.0.0.0:35729/livereload.js?snipver=1" async="" defer=""></script>`. This PR replaces 0.0.0.0 with localhost in this case.