### PR TITLE
chore(packages): add typings to be able to consume it like an API

### DIFF
--- a/package.json
+++ b/package.json
@@ -90,5 +90,6 @@
     "commitizen": {
       "path": "node_modules/ionic-cz-conventional-changelog"
     }
-  }
+  },
+  "typings": "dist/index.d.ts"
 }


### PR DESCRIPTION
#### Short description of what this resolves:
add typings to be able to consume it like an API

example

```ts
import { sass } from "@ionic/app-scripts";
```

