### PR TITLE
feat(): replace worker-client with internal workers

### DIFF
--- a/src/cleancss.ts
+++ b/src/cleancss.ts
@@ -4,7 +4,6 @@ import { BuildError } from './util/errors';
 import { fillConfigDefaults, generateContext, getUserConfigFile } from './util/config';
 import { Logger } from './logger/logger';
 import { readFileAsync, writeFileAsync } from './util/helpers';
-import { runWorker } from './worker-client';
 import * as cleanCss from 'clean-css';
 
 
@@ -14,7 +13,7 @@ export function cleancss(context?: BuildContext, configFile?: string) {
 
   const logger = new Logger('cleancss');
 
-  return runWorker('cleancss', 'cleancssWorker', context, configFile)
+  return cleancssWorker(context, configFile)
     .then(() => {
       logger.finish();
     })
@@ -32,27 +31,31 @@ export function cleancssWorker(context: BuildContext, configFile: string): Promi
 
     Logger.debug(`cleancss read: ${srcFile}`);
 
-    readFileAsync(srcFile).then(fileContent => {
-      const minifier = new cleanCss(cleanCssConfig.options);
-      minifier.minify(fileContent, (err, minified) => {
-        if (err) {
-          reject(new BuildError(err));
+    readFileAsync(srcFile)
+      .then(fileContent => {
+        const minifier = new cleanCss(cleanCssConfig.options);
+        minifier.minify(fileContent, (err, minified) => {
+          if (err) {
+            reject(new BuildError(err));
 
-        } else if (minified.errors && minified.errors.length > 0) {
-          // just return the first error for now I guess
-          minified.errors.forEach(e => {
-            Logger.error(e);
-          });
-          reject(new BuildError());
+          } else if (minified.errors && minified.errors.length > 0) {
+            // just return the first error for now I guess
+            minified.errors.forEach(e => {
+              Logger.error(e);
+            });
+            reject(new BuildError());
 
-        } else {
-          Logger.debug(`cleancss write: ${destFile}`);
-          writeFileAsync(destFile, minified.styles).then(() => {
-            resolve();
-          });
-        }
+          } else {
+            Logger.debug(`cleancss write: ${destFile}`);
+            writeFileAsync(destFile, minified.styles).then(() => {
+              resolve();
+            });
+          }
+        });
+      })
+      .catch(err => {
+        reject(new BuildError(err));
       });
-    });
 
   });
 }

--- a/src/uglifyjs.ts
+++ b/src/uglifyjs.ts
@@ -3,7 +3,6 @@ import { BuildError } from './util/errors';
 import { fillConfigDefaults, generateContext, getUserConfigFile } from './util/config';
 import { join } from 'path';
 import { Logger } from './logger/logger';
-import { runWorker } from './worker-client';
 import { writeFileAsync } from './util/helpers';
 import * as uglify from 'uglify-js';
 
@@ -14,7 +13,7 @@ export function uglifyjs(context?: BuildContext, configFile?: string) {
 
   const logger = new Logger('uglifyjs');
 
-  return runWorker('uglifyjs', 'uglifyjsWorker', context, configFile)
+  return uglifyjsWorker(context, configFile)
     .then(() => {
       logger.finish();
     })


### PR DESCRIPTION
#### Short description of what this resolves:
In my cleancss.config.js and uglifyjs.config.js, I am dependent on npm args. However the worker-client is being spawned as another process, which is causing the args not to be passed.

#### Changes proposed in this pull request:

- replace worker-client with local workers

**Fixes**: #463

