### PR TITLE
feat: add `--ignorets` flag to allow building despite TS errors, fixes #443

### DIFF
--- a/src/dev-server/serve-config.ts
+++ b/src/dev-server/serve-config.ts
@@ -13,6 +13,7 @@ export interface ServeConfig {
   useServerLogs: boolean;
   notifyOnConsoleLog: boolean;
   useProxy: boolean;
+  ignoreTsErrors: boolean;
 }
 export const LOGGER_DIR = '__ion-dev-server';
 export const IONIC_LAB_URL = '/ionic-lab';

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -31,7 +31,8 @@ export function serve(context?: BuildContext) {
     notificationPort: getNotificationPort(context),
     useServerLogs: useServerLogs(context),
     useProxy: useProxy(context),
-    notifyOnConsoleLog: sendClientConsoleLogs(context)
+    notifyOnConsoleLog: sendClientConsoleLogs(context),
+    ignoreTsErrors: getIgnoreTsErrors(context)
   };
 
   createNotificationServer(config);
@@ -129,4 +130,8 @@ function useProxy(context: BuildContext) {
 
 function sendClientConsoleLogs(context: BuildContext) {
   return hasConfigValue(context, '--consolelogs', '-c', 'ionic_consolelogs', false);
+}
+
+function getIgnoreTsErrors(context: BuildContext) {
+  return hasConfigValue(context, '--ignorets', '-i', 'ionic_ignore_ts_errors', false);
 }

--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -119,7 +119,7 @@ export function transpileWorker(context: BuildContext, workerConfig: TranspileWo
 
     const diagnostics = runTypeScriptDiagnostics(context, tsDiagnostics);
 
-    if (diagnostics.length) {
+    if (diagnostics.length && !context.ignoreTsErrors) {
       // darn, we've got some things wrong, transpile failed :(
       printDiagnostics(context, DiagnosticsType.TypeScript, diagnostics, true, true);
 
@@ -175,7 +175,7 @@ function transpileUpdateWorker(event: string, filePath: string, context: BuildCo
 
     const diagnostics = runTypeScriptDiagnostics(context, transpileOutput.diagnostics);
 
-    if (diagnostics.length) {
+    if (diagnostics.length && !context.ignoreTsErrors) {
       printDiagnostics(context, DiagnosticsType.TypeScript, diagnostics, false, true);
 
       // darn, we've got some errors with this transpiling :(
@@ -328,7 +328,7 @@ export function getTsConfig(context: BuildContext, tsConfigPath?: string): TsCon
 
     const diagnostics = runTypeScriptDiagnostics(context, parsedConfig.errors);
 
-    if (diagnostics.length) {
+    if (diagnostics.length && !context.ignoreTsErrors) {
       printDiagnostics(context, DiagnosticsType.TypeScript, diagnostics, true, true);
       throw new BuildError();
     }


### PR DESCRIPTION
#### Short description of what this resolves:
Ionic 2 beta allowed using a parameter to [override](https://github.com/driftyco/ionic-gulp-tasks/blob/master/browserify-typescript/index.js#L37) its default behavior of canceling builds if it could not fully follow all of the typings. Users who did so, myself included, made a lengthy upgrade to RC (having accumulated ~1k TS errors on working code) only to find out this compatibility had been broken, and faced with the prospect of having to convince superiors to go through a 1w+ process of fixing TS errors, which may be hard to phrase as business value toward them. This PR addresses this by enabling a similar override to side-step the immediate problem.

#### Changes proposed in this pull request:
add a `--ignorets` / `-i` CLI param to allow building despite TS errors

**Fixes**: #443
