### PR TITLE
feat(createWorker): pass argv and config_argv to spawned processes

### DIFF
--- a/src/worker-client.ts
+++ b/src/worker-client.ts
@@ -87,9 +87,10 @@ export function createWorker(taskModule: string): any {
 
   try {
     const workerModule = join(__dirname, 'worker-process.js');
-    const worker = fork(workerModule, [], {
+    const worker = fork(workerModule, process.argv, {
       env: {
-        FORCE_COLOR: true
+        FORCE_COLOR: true,
+        npm_config_argv: process.env.npm_config_argv
       }
     });
 


### PR DESCRIPTION
#### Short description of what this resolves:
In my cleancss.config.js and uglifyjs.config.js, I am dependent on npm args. However the worker-client is being spawned as another process, which is causing the args and npm config argv not to be passed.


#### Changes proposed in this pull request:
- pass the argv

**Fixes**: #463

