### PR TITLE
fix(http-server): log error when failing to read getProjectJson.  If …

### DIFF
--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -38,19 +38,24 @@ export function createHttpServer(config: ServeConfig): express.Application {
 
 function setupProxies(app: express.Application) {
 
-  getProjectJson().then(function(projectConfig: IonicProject) {
-    for (const proxy of projectConfig.proxies || []) {
-      var opts: any = url.parse(proxy.proxyUrl);
-      if (proxy.proxyNoAgent) {
-        opts.agent = false;
+  getProjectJson()
+    .then(
+      (projectConfig: IonicProject)=> {
+        for (const proxy of projectConfig.proxies || []) {
+        var opts: any = url.parse(proxy.proxyUrl);
+        if (proxy.proxyNoAgent) {
+          opts.agent = false;
+        }
+
+        opts.rejectUnauthorized = !(proxy.rejectUnauthorized === false);
+
+        app.use(proxy.path, proxyMiddleware(opts));
+        Logger.info('Proxy added:' + proxy.path + ' => ' + url.format(opts));
       }
-
-      opts.rejectUnauthorized = !(proxy.rejectUnauthorized === false);
-
-      app.use(proxy.path, proxyMiddleware(opts));
-      Logger.info('Proxy added:' + proxy.path + ' => ' + url.format(opts));
+    }, (error)=>{
+        Logger.error("failed to read proxies from Ionic config file:", error);
     }
-  });
+  );
 }
 
 /**


### PR DESCRIPTION
#### Short description of what this resolves:
There was no logging error when `getProjectJson()` failed.  This  [issue](https://github.com/driftyco/ionic/issues/9388) would have been resolved by this fix.  It would have   informed this user of an error in their config file if we allowed the error to bubble up. 

#### Changes proposed in this pull request:

-  Add a second function to the `.then` block.  
-  Converted the callback to be typescript `=>`.

**Fixes**: #
Can't migrate the issue but I found this via: https://github.com/driftyco/ionic/issues/9388