### PR TITLE
Livereload run fix

### DIFF
--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -99,6 +99,10 @@ function servePlatformResource(req: express.Request, res: express.Response, next
   const userAgent = req.header('user-agent');
   let resourcePath = config.wwwDir;
 
+  if (!config.isCordovaServe) {
+    return next();
+  }
+
   if (isUserAgentIOS(userAgent)) {
     resourcePath = path.join(config.rootDir, IOS_PLATFORM_PATH);
   } else if (isUserAgentAndroid(userAgent)) {

--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -4,7 +4,13 @@ import { injectLiveReloadScript } from './live-reload';
 import * as express from 'express';
 import * as fs from 'fs';
 import * as url from 'url';
-import { ServeConfig, LOGGER_DIR, IONIC_LAB_URL } from './serve-config';
+import {
+  ServeConfig,
+  LOGGER_DIR,
+  IONIC_LAB_URL,
+  IOS_PLATFORM_PATH,
+  ANDROID_PLATFORM_PATH
+} from './serve-config';
 import { Logger } from '../logger/logger';
 import * as proxyMiddleware from 'proxy-middleware';
 import { injectDiagnosticsHtml } from '../logger/logger-diagnostics';
@@ -27,7 +33,9 @@ export function createHttpServer(config: ServeConfig): express.Application {
   app.use(`/${LOGGER_DIR}`, express.static(path.join(__dirname, '..', '..', 'bin'), { maxAge: 31536000 }));
   app.get(IONIC_LAB_URL, (req, res) =>
     res.sendFile('ionic-lab.html', {root: path.join(__dirname, '..', '..', 'bin')}));
-  app.get('/cordova.js', serveCordovaJS);
+  app.get('/cordova.js', servePlatformResource, serveMockCordovaJS);
+  app.get('/cordova_plugins.js', servePlatformResource);
+  app.get('/plugins/*', servePlatformResource);
 
   if (config.useProxy) {
     setupProxies(app);
@@ -40,7 +48,7 @@ function setupProxies(app: express.Application) {
 
   getProjectJson().then(function(projectConfig: IonicProject) {
     for (const proxy of projectConfig.proxies || []) {
-      var opts: any = url.parse(proxy.proxyUrl);
+      let opts: any = url.parse(proxy.proxyUrl);
       if (proxy.proxyNoAgent) {
         opts.agent = false;
       }
@@ -78,7 +86,41 @@ function serveIndex(req: express.Request, res: express.Response)  {
 /**
  * http responder for cordova.js file
  */
-function serveCordovaJS(req: express.Request, res: express.Response) {
+function serveMockCordovaJS(req: express.Request, res: express.Response) {
   res.set('Content-Type', 'application/javascript');
   res.send('// mock cordova file during development');
+}
+
+/**
+ * Middleware to serve platform resources
+ */
+function servePlatformResource(req: express.Request, res: express.Response, next: express.NextFunction) {
+  const config: ServeConfig = req.app.get('serveConfig');
+  const userAgent = req.header('user-agent');
+  let resourcePath = config.wwwDir;
+
+  if (isUserAgentIOS(userAgent)) {
+    resourcePath = path.join(config.rootDir, IOS_PLATFORM_PATH);
+  } else if (isUserAgentAndroid(userAgent)) {
+    resourcePath = path.join(config.rootDir, ANDROID_PLATFORM_PATH);
+  }
+
+  fs.stat(path.join(resourcePath, req.url), (err, stats) => {
+    if (err) {
+      return next();
+    }
+    res.sendFile(req.url, { root: resourcePath });
+  });
+}
+
+
+
+function isUserAgentIOS(ua: string) {
+  ua = ua.toLowerCase();
+  return (ua.indexOf('iphone') > -1 || ua.indexOf('ipad') > -1 || ua.indexOf('ipod') > -1);
+}
+
+function isUserAgentAndroid(ua: string) {
+  ua = ua.toLowerCase();
+  return ua.indexOf('android') > -1;
 }

--- a/src/dev-server/serve-config.ts
+++ b/src/dev-server/serve-config.ts
@@ -1,3 +1,5 @@
+import * as path from 'path';
+
 export interface ServeConfig {
   httpPort: number;
   host: string;
@@ -16,3 +18,6 @@ export interface ServeConfig {
 }
 export const LOGGER_DIR = '__ion-dev-server';
 export const IONIC_LAB_URL = '/ionic-lab';
+
+export const IOS_PLATFORM_PATH = path.join('platforms', 'ios', 'www');
+export const ANDROID_PLATFORM_PATH = path.join('platforms', 'android', 'assets', 'www');

--- a/src/dev-server/serve-config.ts
+++ b/src/dev-server/serve-config.ts
@@ -6,6 +6,7 @@ export interface ServeConfig {
   rootDir: string;
   wwwDir: string;
   buildDir: string;
+  isCordovaServe: boolean;
   launchBrowser: boolean;
   launchLab: boolean;
   browserToLaunch: string;

--- a/src/serve.ts
+++ b/src/serve.ts
@@ -23,6 +23,7 @@ export function serve(context?: BuildContext) {
     rootDir: context.rootDir,
     wwwDir: context.wwwDir,
     buildDir: context.buildDir,
+    isCordovaServe: isCordovaServe(context),
     launchBrowser: launchBrowser(context),
     launchLab: launchLab(context),
     browserToLaunch: browserToLaunch(context),
@@ -97,6 +98,10 @@ export function getNotificationPort(context: BuildContext) {
 
 function useServerLogs(context: BuildContext) {
   return hasConfigValue(context, '--serverlogs', '-s', 'ionic_serverlogs', false);
+}
+
+function isCordovaServe(context: BuildContext) {
+  return hasConfigValue(context, '--iscordovaserve', '-z', 'ionic_cordova_serve', false);
 }
 
 function launchBrowser(context: BuildContext) {


### PR DESCRIPTION
#### Short description of what this resolves:
There was a regression in 2.1.8 when we moved `run` and `emulate` serve responsiblity away from cli to app-scripts. This adds the logic within app-scripts to serve cordova plugins through express to emulators or devices.

This does add one flag to the `serve` command that indicates when the serve command should be accessed from a native device. This is named `--iscordovaserve`

**Fixes**: #467
