### PR TITLE
Fixes error with templateUpdate and multiple js files on same path

### DIFF
--- a/src/template.ts
+++ b/src/template.ts
@@ -54,7 +54,7 @@ function updateCorrespondingJsFile(context: BuildContext, newTemplateContent: st
   const javascriptFiles = context.fileCache.getAll().filter((file: File) => dirname(file.path) === dirname(existingHtmlTemplatePath) && extname(file.path) === '.js');
   for (const javascriptFile of javascriptFiles) {
     const newContent = replaceExistingJsTemplate(javascriptFile.content, newTemplateContent, existingHtmlTemplatePath);
-    if (newContent !== javascriptFile.content) {
+    if (newContent !== null && newContent !== javascriptFile.content) {
       javascriptFile.content = newContent;
       // set the file again to generate a new timestamp
       // do the same for the typescript file just to invalidate any caches, etc.

--- a/src/template.ts
+++ b/src/template.ts
@@ -54,7 +54,7 @@ function updateCorrespondingJsFile(context: BuildContext, newTemplateContent: st
   const javascriptFiles = context.fileCache.getAll().filter((file: File) => dirname(file.path) === dirname(existingHtmlTemplatePath) && extname(file.path) === '.js');
   for (const javascriptFile of javascriptFiles) {
     const newContent = replaceExistingJsTemplate(javascriptFile.content, newTemplateContent, existingHtmlTemplatePath);
-    if (newContent !== null && newContent !== javascriptFile.content) {
+    if (newContent && newContent !== javascriptFile.content) {
       javascriptFile.content = newContent;
       // set the file again to generate a new timestamp
       // do the same for the typescript file just to invalidate any caches, etc.


### PR DESCRIPTION
#### Short description of what this resolves:
Fixes error with templateUpdate and multiple js files on same path.
replaceExistingJsTemplate return null if no template is found and then it sets javascriptFile.content = null making it fail the next time it tries to build

still fails if saving a template twice without any changes but im not sure it should even reach this part if the file has no changes? 

#### Changes proposed in this pull request:

-
-
-

**Fixes**: #

