### PR TITLE
chore(config): add swtoolbox to copy

### DIFF
--- a/config/copy.config.js
+++ b/config/copy.config.js
@@ -17,5 +17,9 @@ module.exports = {
   copyPolyfills: {
     src: ['{{ROOT}}/node_modules/ionic-angular/polyfills/polyfills.js'],
     dest: '{{BUILD}}'
+  },
+  copySwToolbox: {
+    src: ['{{ROOT}}/node_modules/sw-toolbox/sw-toolbox.js'],
+    dest: '{{BUILD}}'
   }
 }


### PR DESCRIPTION
#### Short description of what this resolves:
Do not merge until https://github.com/driftyco/ionic2-app-base/pull/118 is merged. This adds the copy config entry to copy` sw-toolbox.js` to build.

#### Changes proposed in this pull request:

- add a copy config entry
