### PR TITLE
feat(sass): enable Sass indented files compilation

### DIFF
--- a/config/sass.config.js
+++ b/config/sass.config.js
@@ -53,7 +53,7 @@ module.exports = {
    * the file will be excluded.
    */
   includeFiles: [
-    /\.(scss)$/i
+    /\.(s(c|a)ss)$/i
   ],
 
   /**

--- a/config/watch.config.js
+++ b/config/watch.config.js
@@ -9,7 +9,7 @@ var copyConfig = require('./copy.config');
 
 module.exports = {
   srcFiles: {
-    paths: ['{{SRC}}/**/*.(ts|html|scss)'],
+    paths: ['{{SRC}}/**/*.(ts|html|s(c|a)ss)'],
     options: { ignored: ['{{SRC}}/**/*.spec.ts', '{{SRC}}/**/*.e2e.ts', '**/*.DS_Store'] },
     callback: watch.buildUpdate
   },


### PR DESCRIPTION
#### Short description of what this resolves:
ionic-app-scripts does not compile nor watch Sass indented files

#### Changes proposed in this pull request:
- Change sass.config.includeFiles and watch.config regular expressions to match *.sass and *.scss files