### PR TITLE
chore(README): update example package.json config

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Ionic projects use the `package.json` file for configuration. There's a handy [c
 ```
   "config": {
     "ionic_bundler": "rollup",
-    "ionic_source_map": "source-map",
+    "ionic_source_map_type": "source-map",
     "ionic_cleancss": "./config/cleancss.config.js"
   },
 ```


### PR DESCRIPTION
#### Short description of what this resolves:

In the 0.0.47 release the `ionic_source_map_type` config was renamed to `ionic_source_map_type`. This commit update the example package.json config to use the new name.