### PR TITLE
Temporary fix to keep custom decorators when aot compiling

### DIFF
--- a/src/aot/aot-compiler.ts
+++ b/src/aot/aot-compiler.ts
@@ -124,8 +124,11 @@ export class AotCompiler {
     .then(() => {
       const tsFiles = this.context.fileCache.getAll().filter(file => extname(file.path) === '.ts' && file.path.indexOf('.d.ts') === -1);
       for (const tsFile of tsFiles) {
-        const cleanedFileContent = removeDecorators(tsFile.path, tsFile.content);
-        tsFile.content = cleanedFileContent;
+        // Temporary fix to keep custom decorators until a
+        // proper resolution can be found.
+        /*const cleanedFileContent = removeDecorators(tsFile.path, tsFile.content);
+        tsFile.content = cleanedFileContent;*/
+        const cleanedFileContent = tsFile.content;
         const transpileOutput = this.transpileFileContent(tsFile.path, cleanedFileContent, this.tsConfig.parsed.options);
         const diagnostics = runTypeScriptDiagnostics(this.context, transpileOutput.diagnostics);
         if (diagnostics.length) {


### PR DESCRIPTION
#### Short description of what this resolves:

Preserves custom decorators to support libraries such as ngrx/effects.

See [here](https://github.com/driftyco/ionic-app-scripts/issues/545) for a transcript of the issue.
