### PR TITLE
Make sure the inSourceMap gets passed to uglifyjs

### DIFF
--- a/src/uglifyjs.ts
+++ b/src/uglifyjs.ts
@@ -56,6 +56,7 @@ function runUglifyInternal(uglifyJsConfig: UglifyJsConfig): uglify.MinifyOutput 
   return uglify.minify(uglifyJsConfig.sourceFile, {
     compress: uglifyJsConfig.compress,
     mangle: uglifyJsConfig.mangle,
+    inSourceMap : uglifyJsConfig.inSourceMap,
     outSourceMap: uglifyJsConfig.outSourceMap
   });
 }


### PR DESCRIPTION
#### Short description of what this resolves:
inSourceMap not being used during uglification.

#### Changes proposed in this pull request:

- Pass the inSourceMap setting to uglifyjs.minify

**Fixes**: #613
