### PR TITLE
Fix exception when no ws clients connected during rebuild

### DIFF
--- a/src/dev-server/notification-server.ts
+++ b/src/dev-server/notification-server.ts
@@ -22,11 +22,11 @@ export function createNotificationServer(config: ServeConfig) {
 
   // drain the queue messages when the server is ready
   function drainMessageQueue(options = { broadcast: false }) {
-    let sendMethod = wsServer.send;
+    let sendMethod = wsServer && wsServer.send;
     if (options.hasOwnProperty('broadcast') && options.broadcast) {
       sendMethod = wss.broadcast;
     }
-    if (wss.clients.length > 0) {
+    if (sendMethod && wss.clients.length > 0) {
       let msg: any;
       while (msg = msgToClient.shift()) {
         try {


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes an issue where a rebuild is started during `ionic serve` from a file change, when no browsers are loaded with the app running.

#### Changes proposed in this pull request:

- Guard against an undefined `wsServer`

**Fixes**: #590 #599 #535 
