### PR TITLE
Fix(typo): Properly appends

### DIFF
--- a/src/aot/utils.ts
+++ b/src/aot/utils.ts
@@ -96,7 +96,7 @@ function getPlatformBrowserFunctionNode(filePath: string, fileContent: string) {
     modifiedFileContent = appendBefore(filePath, modifiedFileContent, callsToPlatformBrowser[0].expression, toAppend);
   } else {
     // just throw it at the bottom
-    modifiedFileContent + toAppend;
+    modifiedFileContent += toAppend;
   }
   return modifiedFileContent;
 }


### PR DESCRIPTION
I haven't been able to get NGC to kick in using different flags as mentioned at d53f25f, this typo might be the cause of the issue.

#### Short description of what this resolves:

A typo that was pushed to the repo on [5d82829](https://github.com/driftyco/ionic-app-scripts/commit/0594803ca5b2136e666c3007540491ad2e72f06c#diff-29ed0d301ecfa6169cc5c75c1e54a6e4R99)

