### PR TITLE
Allow user config to be function

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -162,6 +162,11 @@ export function fillConfigDefaults(userConfigFile: string, defaultConfigFile: st
       statSync(userConfigFile);
       // create a fresh copy of the config each time
       userConfig = require(userConfigFile);
+      
+      // if user config returns a function call it to determine proper object
+      if (typeof userconfig === 'function') {
+         userConfig = userConfig(); 
+      }  
     } catch (e) {
       if (e.code === 'ENOENT') {
         console.error(`Config file "${userConfigFile}" not found. Using defaults instead.`);


### PR DESCRIPTION
#### Short description of what this resolves:

This allows custom configs to run as a function so that logic can be executed and determined at runtime.

#### Changes proposed in this pull request:

- Adds a simple logic gate to detect if config that is required returns a function. If so call it to retrieve assignable object.


**Fixes**: #666