### PR TITLE
chore(ionicons): remove the import of ionicons css

### DIFF
--- a/config/sass.config.js
+++ b/config/sass.config.js
@@ -42,7 +42,6 @@ module.exports = {
    */
   includePaths: [
     'node_modules/ionic-angular/themes',
-    'node_modules/ionicons/dist/scss',
     'node_modules/ionic-angular/fonts'
   ],
 


### PR DESCRIPTION
#### Short description of what this resolves:

Removes `ionicons` from the `includePaths` to avoid getting CSS that we don't want.

------------------------------------------------------------------------------------

**IMPORTANT:**
This is dependent on driftyco/ionic#10115. If you try to use this Sass config without that PR it will throw errors that it can't find `ionicons-icons` or `ionicons-variables`.