### PR TITLE
Alias environment specific module (to change API keys, constants in c…

### DIFF
--- a/config/webpack.config.js
+++ b/config/webpack.config.js
@@ -14,7 +14,9 @@ module.exports = {
 
   resolve: {
     extensions: ['.ts', '.js', '.json'],
-    modules: [path.resolve('node_modules')]
+    alias: {
+      "@app/config": path.resolve('./src/config/config.' + process.env.IONIC_ENV + '.ts')
+    }
   },
 
   module: {


### PR DESCRIPTION
#### Short description of what this resolves:
Allows environment-based configuration at the code-level. 

#### Changes proposed in this pull request:
Using a module alias in Webpack, allow users to utilize environment-based configuration in their app code.

I've seen a lot of requests and half-measures researching this today and thought I could contribute to the base idea of how this can be accomplished.

This is a quick proof of what can be done. I am willing to help contribute upon this concept and expand it to a form that works for the Ionic team.