### PR TITLE
fix(build): fix test if linting should trigger on file change

### DIFF
--- a/src/build.ts
+++ b/src/build.ts
@@ -171,9 +171,11 @@ export function buildUpdate(changedFiles: ChangedFile[], context: BuildContext) 
 
         let requiresLintUpdate = false;
         for (const changedFile of changedFiles) {
-          if (changedFile.ext === '.ts' && changedFile.event === 'change') {
-            requiresLintUpdate = true;
-            break;
+          if (changedFile.ext === '.ts') {
+            if (changedFile.event === 'change' || changedFile.event === 'add') {
+              requiresLintUpdate = true;
+              break;
+            }
           }
         }
         if (requiresLintUpdate) {

--- a/src/build.ts
+++ b/src/build.ts
@@ -171,7 +171,7 @@ export function buildUpdate(changedFiles: ChangedFile[], context: BuildContext) 
 
         let requiresLintUpdate = false;
         for (const changedFile of changedFiles) {
-          if (changedFile.ext === '.ts' && changedFile.event === 'ch') {
+          if (changedFile.ext === '.ts' && changedFile.event === 'change') {
             requiresLintUpdate = true;
             break;
           }


### PR DESCRIPTION
#### Short description of what this resolves:
Fix test if linting should trigger on file change. It was checking on the event being `ch` instead of `change`.

**Fixes**: #718 
