### PR TITLE
chore(build): fix build issues with typescript 2.1

### DIFF
--- a/src/babili.ts
+++ b/src/babili.ts
@@ -20,7 +20,7 @@ export function babili(context: BuildContext, configFile?: string) {
 }
 
 
-export function babiliWorker(context: BuildContext, configFile: string): Promise<any> {
+export function babiliWorker(context: BuildContext, configFile: string) {
   const babiliConfig: BabiliConfig = fillConfigDefaults(configFile, taskInfo.defaultConfigFile);
   // TODO - figure out source maps??
   return runBabili(context, babiliConfig).then((minifiedCode: string) => {

--- a/src/minify.ts
+++ b/src/minify.ts
@@ -32,7 +32,7 @@ function minifyWorker(context: BuildContext) {
 }
 
 
-export function minifyJs(context: BuildContext) {
+export function minifyJs(context: BuildContext): Promise<void> {
   return isClosureSupported(context).then((result: boolean) => {
     if (result) {
       return closure(context);

--- a/src/util/helpers.ts
+++ b/src/util/helpers.ts
@@ -95,7 +95,7 @@ export function titleCase(str: string) {
 }
 
 
-export function writeFileAsync(filePath: string, content: string): Promise<any> {
+export function writeFileAsync(filePath: string, content: string) {
   return new Promise((resolve, reject) => {
     writeFile(filePath, content, (err) => {
       if (err) {
@@ -106,8 +106,8 @@ export function writeFileAsync(filePath: string, content: string): Promise<any> 
   });
 }
 
-export function readFileAsync(filePath: string): Promise<string> {
-  return new Promise((resolve, reject) => {
+export function readFileAsync(filePath: string) {
+  return new Promise<string>((resolve, reject) => {
     readFile(filePath, 'utf-8', (err, buffer) => {
       if (err) {
         return reject(err);
@@ -128,7 +128,7 @@ export function readAndCacheFile(filePath: string, purge: boolean = false): Prom
   });
 }
 
-export function unlinkAsync(filePath: string|string[]): Promise<any> {
+export function unlinkAsync(filePath: string|string[]) {
   let filePaths: string[];
 
   if (typeof filePath === 'string') {
@@ -140,7 +140,7 @@ export function unlinkAsync(filePath: string|string[]): Promise<any> {
   }
 
   let promises = filePaths.map(filePath => {
-    return new Promise((resolve, reject) => {
+    return new Promise<void>((resolve, reject) => {
       unlink(filePath, (err: Error) => {
         if (err) {
           return reject(err);
@@ -153,8 +153,8 @@ export function unlinkAsync(filePath: string|string[]): Promise<any> {
   return Promise.all(promises);
 }
 
-export function rimRafAsync(directoryPath: string): Promise<null> {
-  return new Promise((resolve, reject) => {
+export function rimRafAsync(directoryPath: string) {
+  return new Promise<void>((resolve, reject) => {
     remove(directoryPath, (err: Error) => {
       if (err) {
         return reject(err);
@@ -164,8 +164,8 @@ export function rimRafAsync(directoryPath: string): Promise<null> {
   });
 }
 
-export function copyFileAsync(srcPath: string, destPath: string): Promise<any> {
-  return new Promise((resolve, reject) => {
+export function copyFileAsync(srcPath: string, destPath: string) {
+  return new Promise<void>((resolve, reject) => {
     const writeStream = createWriteStream(destPath);
 
     writeStream.on('error', (err: Error) => {
@@ -180,8 +180,8 @@ export function copyFileAsync(srcPath: string, destPath: string): Promise<any> {
   });
 }
 
-export function readDirAsync(pathToDir: string): Promise<string[]> {
-  return new Promise((resolve, reject) => {
+export function readDirAsync(pathToDir: string) {
+  return new Promise<string[]>((resolve, reject) => {
     readdir(pathToDir, (err: Error, fileNames: string[]) => {
       if (err) {
         return reject(err);

--- a/src/util/source-maps.ts
+++ b/src/util/source-maps.ts
@@ -6,12 +6,12 @@ import { BuildContext } from './interfaces';
 export function purgeSourceMapsIfNeeded(context: BuildContext): Promise<any> {
   if (getBooleanPropertyValue(Constants.ENV_VAR_GENERATE_SOURCE_MAP)) {
     // keep the source maps and just return
-    return Promise.resolve();
+    return Promise.resolve([]);
   }
-  return readDirAsync(context.buildDir).then((fileNames: string[]) => {
+  return readDirAsync(context.buildDir).then((fileNames) => {
     const sourceMaps = fileNames.filter(fileName => fileName.endsWith('.map'));
     const fullPaths = sourceMaps.map(sourceMap => join(context.buildDir, sourceMap));
-    const promises: Promise<any>[] = [];
+    const promises: Promise<void>[] = [];
     for (const fullPath of fullPaths) {
       promises.push(unlinkAsync(fullPath));
     }


### PR DESCRIPTION
#### Short description of what this resolves:
The code base was not yet ready for TypeScript 2.1, spitting out some type errors when running `npm run build`.

This patch fixes some type annotations to be compatible with both TypeScript 2.0 and 2.1.

This is one step in fixing #197 (and #649 where support for TypeScript 2.1 seems to be a pre-condition).