### PR TITLE
fix(serve): assign all ports dynamically

### DIFF
--- a/src/util/network.ts
+++ b/src/util/network.ts
@@ -1,5 +1,10 @@
 import * as net from 'net';
 
+export function findClosestOpenPorts(host: string, ports: number[]): Promise<number[]> {
+  const promises = ports.map(port => findClosestOpenPort(host, port));
+  return Promise.all(promises);
+}
+
 export function findClosestOpenPort(host: string, port: number): Promise<number> {
   function t(portToCheck: number): Promise<number> {
     return isPortTaken(host, portToCheck).then(isTaken => {


### PR DESCRIPTION
#### Short description of what this resolves:

Up to now only the logger port was dynamically increased if another app
is running already. This meant that manually specifying port arguments
for server and live reload was needed when directly using the
`ionic-app-scripts server` command. The `ionic` CLI command does
already take care of this.

#### Changes proposed in this pull request:

This patch ensures all the ports are chosen dynamically, so it's now
possible to run two applications without any manual intervention.

**Fixes**: #694 
