### PR TITLE
chore(dependencies): upgrade TS to latest minor

### DIFF
--- a/package.json
+++ b/package.json
@@ -95,7 +95,7 @@
     "rxjs": "^5.0.1",
     "sw-toolbox": "3.4.0",
     "tslint-ionic-rules": "0.0.8",
-    "typescript": "~2.0.10",
+    "typescript": "^2.0.10",
     "zone.js": "^0.7.2"
   },
   "peerDependencies": {


### PR DESCRIPTION
#### Short description of what this resolves:

Allows upgrading to TypeScript 2.x (e.g. to 2.1.6) because:
1) it is backward compatible
2) users of `ionic-app-scripts` may use other modules requiring 2.1.x and higher.

#### Changes proposed in this pull request:

- update package.json

**Fixes**: https://github.com/DefinitelyTyped/DefinitelyTyped/issues/14579