### PR TITLE
fix(readConfigJson): Setting readConfigJson constant wrong

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -119,7 +119,7 @@ export function generateContext(context?: BuildContext): BuildContext {
   setProcessEnvVar(Constants.ENV_TS_CONFIG, tsConfigPathValue);
   Logger.debug(`tsconfig set to ${tsConfigPathValue}`);
 
-  const readConfigJson = resolve(getConfigValue(context, '--readConfigJson', null, Constants.ENV_READ_CONFIG_JSON, Constants.ENV_READ_CONFIG_JSON.toLowerCase(), 'true'));
+  const readConfigJson = getConfigValue(context, '--readConfigJson', null, Constants.ENV_READ_CONFIG_JSON, Constants.ENV_READ_CONFIG_JSON.toLowerCase(), 'true');
   setProcessEnvVar(Constants.ENV_READ_CONFIG_JSON, readConfigJson);
   Logger.debug(`readConfigJson set to ${readConfigJson}`);
 


### PR DESCRIPTION
#### Short description of what this resolves:
ENV_READ_CONFIG_JSON constant was being set wrong by resolving --readConfigJson argument as path instead of boolean.
That was causing if statement in line 56 of http-server.ts being always false, so the proxies could not load.

**Fixes**: #759 
