### PR TITLE
fix out of memory errors

### DIFF
--- a/bin/ionic-app-scripts.js
+++ b/bin/ionic-app-scripts.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node
+#!/usr/bin/env node --max_old_space_size=2048
 
 if (process.argv.length > 2) {
 


### PR DESCRIPTION
#### Short description of what this resolves:

Fixes `FATAL ERROR: CALL_AND_RETRY_LAST Allocation failed - JavaScript heap out of memory` errors when building with `--prod` flag.  

#### Changes proposed in this pull request:

- adds the `--max-_old_space_size=2048` flag to the `ionic-app-scripts.js` to increase the heap size

**Fixes**: #766
