### PR TITLE
docs(README): add badges for `npm` and `circleci`

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![npm version](https://img.shields.io/npm/v/@ionic/app-scripts.svg)](https://www.npmjs.com/package/@ionic/app-scripts)
+[![Circle CI](https://circleci.com/gh/driftyco/ionic-app-scripts.svg?style=shield&circle-token=:circle-token)](https://circleci.com/gh/driftyco/ionic-app-scripts)
 # Ionic App Scripts
 
 Helper scripts to get [Ionic apps](http://ionicframework.com/) up and running quickly (minus the config overload).


### PR DESCRIPTION
#### Short description of what this resolves:
Add badges in readme. This is especially useful to know which version is the latest, rather than having to go to the changelog everytime.