### PR TITLE
Fix bash script on linux

### DIFF
--- a/bin/ionic-app-scripts.js
+++ b/bin/ionic-app-scripts.js
@@ -1,4 +1,4 @@
-#!/usr/bin/env node --max_old_space_size=2048
+#!/usr/bin/env node
 
 if (process.argv.length > 2) {
 


### PR DESCRIPTION

#### Short description of what this resolves:
Linux only accept one argument in a shebang, so everything after the
/usr/bin/env is seen as one argument.

For setting this node option, see
https://github.com/npm/npm/issues/12238




#### Changes proposed in this pull request:

- Remove shebang argument

**Fixes**: #838
