### PR TITLE
feat(config): add command line flag to disable minifyJs on prod build

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -42,7 +42,7 @@ export function generateContext(context?: BuildContext): BuildContext {
 
   context.runMinifyJs = [
     context.runMinifyJs,
-    context.isProd || hasArg('--minifyJs')
+    (context.isProd && !hasArg('--noMinifyJs')) || hasArg('--minifyJs')
   ].find(val => typeof val === 'boolean');
 
   context.runMinifyCss = [


### PR DESCRIPTION
#### Short description of what this resolves:

I added a command line flag(--noMinifyJs) to disable minifyJs on prod build, so we can use the uglifyJs plugin in webpack config and generate a sourcemap file which is correct. Issue: #856 

#### Changes proposed in this pull request:

- add --noMinifyJs command line flag