### PR TITLE
Propagate errors from webpack stats

### DIFF
--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -124,8 +124,20 @@ export function runWebpackFullBuild(config: WebpackConfig) {
     const callback = (err: Error, stats: any) => {
       if (err) {
         reject(new BuildError(err));
-      } else {
-        resolve(stats);
+      }
+      else {
+        const info = stats.toJson();
+
+        if (stats.hasErrors()) {
+          reject(new BuildError(info.errors));
+        }
+        else if (stats.hasWarnings()) {
+          Logger.warn(info.warnings)
+          resolve(stats);
+        }
+        else {
+          resolve(stats);
+        }
       }
     };
     const compiler = webpackApi(config);

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -132,7 +132,7 @@ export function runWebpackFullBuild(config: WebpackConfig) {
           reject(new BuildError(info.errors));
         }
         else if (stats.hasWarnings()) {
-          Logger.warn(info.warnings)
+          Logger.debug(info.warnings)
           resolve(stats);
         }
         else {


### PR DESCRIPTION
Prior to this patch, the script would only raise "internal" errors raised by webpack and skip "compilation" errors that could be caused by faulty config or source code. This is contrary
to what webpack suggests in terms of error handling[1].

This patch makes it so that any compilation errors will cause ionic to also abort the build, while any compilation warnings will log a warning through ionic's Logger.

[1] https://webpack.js.org/api/node/#error-handling