### PR TITLE
#888 Allow for empty segment

### DIFF
--- a/src/deep-linking/util.ts
+++ b/src/deep-linking/util.ts
@@ -252,7 +252,7 @@ export function convertDeepLinkConfigEntriesToString(entries: DeepLinkConfigEntr
 
 export function convertDeepLinkEntryToJsObjectString(entry: DeepLinkConfigEntry) {
   const defaultHistoryWithQuotes = entry.defaultHistory.map(defaultHistoryEntry => `'${defaultHistoryEntry}'`);
-  const segmentString = entry.segment && entry.segment.length ? `'${entry.segment}'` : null;
+  const segmentString = entry.segment ? `'${entry.segment}'` : null;
   return `{ loadChildren: '${entry.userlandModulePath}${LOAD_CHILDREN_SEPARATOR}${entry.className}', name: '${entry.name}', segment: ${segmentString}, priority: '${entry.priority}', defaultHistory: [${defaultHistoryWithQuotes.join(', ')}] }`;
 }
 


### PR DESCRIPTION
This is useful for people who would like a home page with no segment.

#### Short description of what this resolves:
Resolves defect #888 being unable to have a empty segment in IonicPage

#### Changes proposed in this pull request:
Remove the length check on the entry.segment
-
-
-

**Fixes**: #
