### PR TITLE
Using system wide xdg-open to open browser, fixes #425

### DIFF
--- a/src/serve.ts
+++ b/src/serve.ts
@@ -76,7 +76,11 @@ function onReady(config: ServeConfig, context: BuildContext) {
       .concat(browserOption(context) ? [browserOption(context)] : [])
       .concat(platformOption(context) ? ['?ionicplatform=', platformOption(context)] : []);
 
-    open(openOptions.join(''), browserToLaunch(context));
+    open(openOptions.join(''), browserToLaunch(context),(error:any) => {
+      if (error) {
+        Logger.warn(`Sorry.. unable to open the browser for you: ${error}`);
+      }
+    });
   }
   Logger.info(`dev server running: ${config.hostBaseUrl}/`, 'green', true);
   Logger.newLine();

--- a/src/util/open.ts
+++ b/src/util/open.ts
@@ -43,8 +43,8 @@ export default function (target: string, appName: string | Function, callback?: 
     if (typeof appName === 'string') {
       opener = escape(appName);
     } else {
-      // use Portlands xdg-open everywhere else
-      opener = path.join(__dirname, '../vendor/xdg-open');
+      //use system installed Portlands xdg-open everywhere else
+      opener = 'xdg-open';
     }
     break;
   }


### PR DESCRIPTION
#### Short description of what this resolves:

Browser open doesn't work on unix system because of a reference to a missing external script (vendor/xdg-open).

#### Changes proposed in this pull request:

This is a quick fix what uses xdg-open installed on the system. Works on Ubuntu system and probably in a lot of Linux distribution because xdg-open is quite popular.
I also added a warning message if the system command throws an error.

-
-
-

**Fixes**: #425 
