### PR TITLE
fix(build): fix `extends` in `ts-config.json`

### DIFF
--- a/src/transpile.ts
+++ b/src/transpile.ts
@@ -88,7 +88,7 @@ export function transpileWorker(context: BuildContext, workerConfig: TranspileWo
       tsConfig.options.sourceMap = false;
 
     } else {
-       // build the ts source maps if the bundler is going to use source maps
+      // build the ts source maps if the bundler is going to use source maps
       tsConfig.options.sourceMap = buildJsSourceMaps(context);
     }
 
@@ -113,8 +113,8 @@ export function transpileWorker(context: BuildContext, workerConfig: TranspileWo
     cachedProgram = program;
 
     const tsDiagnostics = program.getSyntacticDiagnostics()
-                          .concat(program.getSemanticDiagnostics())
-                          .concat(program.getOptionsDiagnostics());
+      .concat(program.getSemanticDiagnostics())
+      .concat(program.getOptionsDiagnostics());
 
     const diagnostics = runTypeScriptDiagnostics(context, tsDiagnostics);
 
@@ -300,6 +300,10 @@ function writeTranspiledFilesCallback(fileCache: FileCache, sourcePath: string, 
   }
 }
 
+export async function getTsConfigAsync(context: BuildContext, tsConfigPath?: string): Promise<TsConfig> {
+  return await getTsConfig(context, tsConfigPath);
+}
+
 export function getTsConfig(context: BuildContext, tsConfigPath?: string): TsConfig {
   let config: TsConfig = null;
   tsConfigPath = tsConfigPath || getTsConfigPath(context);
@@ -317,9 +321,9 @@ export function getTsConfig(context: BuildContext, tsConfigPath?: string): TsCon
 
   } else {
     const parsedConfig = ts.parseJsonConfigFileContent(
-                                tsConfigFile.config,
-                                ts.sys, context.rootDir,
-                                {}, tsConfigPath);
+      tsConfigFile.config,
+      ts.sys, context.rootDir,
+      {}, tsConfigPath);
 
     const diagnostics = runTypeScriptDiagnostics(context, parsedConfig.errors);
 


### PR DESCRIPTION
#### Short description of what this resolves:
While typescript support `extends` of another tsconfig, a limitation in `validateRequiredFilesExist` method doesn't as it's reading the file using `fs`, rather than `getTsConfig` which is a wrapper of the `TypeScript API`, 

#### Changes proposed in this pull request:
- Impalement `getTsConfigAsync`  method
- In `validateRequiredFilesExist` use it rather than `readFileAsync` for the `tsconfig.json`

Note: I cannot run Unit Tests

**Fixes**: #745
