### PR TITLE
Gen windows fix

### DIFF
--- a/src/generators/util.ts
+++ b/src/generators/util.ts
@@ -1,4 +1,4 @@
-import { basename, dirname, join, relative } from 'path';
+import { basename, dirname, join, relative, sep } from 'path';
 import { readdirSync } from 'fs';
 import { Logger} from '../logger/logger';
 import { toUnixPath } from '../util/helpers';
@@ -158,7 +158,7 @@ export function nonPageFileManipulation(context: BuildContext, name: string, ngM
     fileContent = content;
     return generateTemplates(context, hydratedRequest);
   }).then(() => {
-    const importPath = toUnixPath(`${relative(dirname(ngModulePath), hydratedRequest.dirToWrite)}/${hydratedRequest.fileName}`);
+    const importPath = toUnixPath(`${relative(dirname(ngModulePath), hydratedRequest.dirToWrite)}${sep}${hydratedRequest.fileName}`);
 
     fileContent = insertNamedImportIfNeeded(ngModulePath, fileContent, hydratedRequest.className, importPath);
     if (type === 'provider') {
@@ -174,7 +174,7 @@ export function tabsModuleManipulation(tabs: string[][], hydratedRequest: Hydrat
   const ngModulePath = tabs[0].find((element: any): boolean => {
     return element.indexOf('module') !== -1;
   });
-  const tabsNgModulePath = `${hydratedRequest.dirToWrite}/${hydratedRequest.fileName}.module.ts`;
+  const tabsNgModulePath = `${hydratedRequest.dirToWrite}${sep}${hydratedRequest.fileName}.module.ts`;
   const importPath = toUnixPath(relative(dirname(tabsNgModulePath), ngModulePath.replace('.module.ts', '')));
 
   return readFileAsync(tabsNgModulePath).then((content) => {

--- a/src/generators/util.ts
+++ b/src/generators/util.ts
@@ -1,6 +1,7 @@
 import { basename, dirname, join, relative } from 'path';
 import { readdirSync } from 'fs';
 import { Logger} from '../logger/logger';
+import { toUnixPath } from '../util/helpers';
 
 import * as Constants from '../util/constants';
 import * as GeneratorConstants from './constants';
@@ -157,7 +158,9 @@ export function nonPageFileManipulation(context: BuildContext, name: string, ngM
     fileContent = content;
     return generateTemplates(context, hydratedRequest);
   }).then(() => {
-    fileContent = insertNamedImportIfNeeded(ngModulePath, fileContent, hydratedRequest.className, `${relative(dirname(ngModulePath), hydratedRequest.dirToWrite)}/${hydratedRequest.fileName}`);
+    const importPath = toUnixPath(`${relative(dirname(ngModulePath), hydratedRequest.dirToWrite)}/${hydratedRequest.fileName}`);
+
+    fileContent = insertNamedImportIfNeeded(ngModulePath, fileContent, hydratedRequest.className, importPath);
     if (type === 'provider') {
       fileContent = appendNgModuleDeclaration(ngModulePath, fileContent, hydratedRequest.className, type);
     } else {
@@ -172,10 +175,11 @@ export function tabsModuleManipulation(tabs: string[][], hydratedRequest: Hydrat
     return element.indexOf('module') !== -1;
   });
   const tabsNgModulePath = `${hydratedRequest.dirToWrite}/${hydratedRequest.fileName}.module.ts`;
+  const importPath = toUnixPath(relative(dirname(tabsNgModulePath), ngModulePath.replace('.module.ts', '')));
 
   return readFileAsync(tabsNgModulePath).then((content) => {
     let fileContent = content;
-    fileContent = insertNamedImportIfNeeded(tabsNgModulePath, fileContent, tabHydratedRequests[0].className, relative(dirname(tabsNgModulePath), ngModulePath.replace('.module.ts', '')));
+    fileContent = insertNamedImportIfNeeded(tabsNgModulePath, fileContent, tabHydratedRequests[0].className, importPath);
     fileContent = appendNgModuleDeclaration(tabsNgModulePath, fileContent, tabHydratedRequests[0].className);
 
     return writeFileAsync(tabsNgModulePath, fileContent);


### PR DESCRIPTION
#### Short description of what this resolves:
ES2015 imports should always have unix style paths, previously on windows our code would insert an import that used a windows style path.

#### Changes proposed in this pull request:

- use `toUnixPath` to transform our generated paths for imports

**Fixes**: https://github.com/driftyco/ionic-cli/issues/2150
