### PR TITLE
fix(webpack): fix issue where bundles output to build dir sub directo…

### DIFF
--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -113,7 +113,7 @@ function webpackBuildComplete(stats: any, context: BuildContext, webpackConfig: 
 
 export function writeBundleFilesToDisk(context: BuildContext) {
   const bundledFilesToWrite = context.fileCache.getAll().filter(file => {
-    return dirname(file.path) === context.buildDir && (file.path.endsWith('.js') || file.path.endsWith('.js.map'));
+    return dirname(file.path).indexOf(context.buildDir) > -1 && (file.path.endsWith('.js') || file.path.endsWith('.js.map'));
   });
   context.bundledFilePaths = bundledFilesToWrite.map(bundledFile => bundledFile.path);
   const promises = bundledFilesToWrite.map(bundledFileToWrite => writeFileAsync(bundledFileToWrite.path, bundledFileToWrite.content));

--- a/src/webpack.ts
+++ b/src/webpack.ts
@@ -113,7 +113,7 @@ function webpackBuildComplete(stats: any, context: BuildContext, webpackConfig: 
 
 export function writeBundleFilesToDisk(context: BuildContext) {
   const bundledFilesToWrite = context.fileCache.getAll().filter(file => {
-    return dirname(file.path).indexOf(context.buildDir) > -1 && (file.path.endsWith('.js') || file.path.endsWith('.js.map'));
+    return dirname(file.path).indexOf(context.buildDir) >= 0 && (file.path.endsWith('.js') || file.path.endsWith('.js.map'));
   });
   context.bundledFilePaths = bundledFilesToWrite.map(bundledFile => bundledFile.path);
   const promises = bundledFilesToWrite.map(bundledFileToWrite => writeFileAsync(bundledFileToWrite.path, bundledFileToWrite.content));


### PR DESCRIPTION
…ry are not emitted

#### Short description of what this resolves:

Webpack not emitting bundles in build directory's subdirs.

**Fixes**: #932
