### PR TITLE
fix(config): in `generateContext` also set `fileCache` if it's not de…

### DIFF
--- a/src/util/config.ts
+++ b/src/util/config.ts
@@ -24,7 +24,10 @@ import * as Constants from './constants';
 export function generateContext(context?: BuildContext): BuildContext {
   if (!context) {
     context = {};
-    context.fileCache = new FileCache();
+  }
+  
+  if (!context.fileCache) {
+     context.fileCache = new FileCache();
   }
 
   context.isProd = [


### PR DESCRIPTION



#### Short description of what this resolves:
If I use `generateContext` from your API and pass an argument . example

```
import { copy, cleancss, build, sass, generateContext } from "@ionic/app-scripts";
	const buildContext = generateContext({
		isProd: true
	});
```

I will get an error because `fileCache` is required example in https://github.com/driftyco/ionic-app-scripts/blob/73a744b2b8cc5dbd515264c253f6682b9fafa029/src/aot/aot-compiler.ts#L78

#### Changes proposed in this pull request:

- if `fileCache` is not defined, create a new instance of it.

Another workaround would be, to export `fileCache` as currently the class in internal

Fixes: #952