### PR TITLE
fix(diagnostics): change direction to always be ltr

### DIFF
--- a/src/dev-client/sass/_diagnostics.scss
+++ b/src/dev-client/sass/_diagnostics.scss
@@ -4,6 +4,8 @@
 }
 
 #ion-diagnostics {
+  direction: ltr;
+  
   position: absolute;
   top: 0;
   right: 0;


### PR DESCRIPTION
#### Short description of what this resolves:
Diagnostics data is errors in English and should show from left to right, even when developing rtl apps, especially as it is not a part of the core framework

#### Changes proposed in this pull request:
- Add direction for ` #ion-diagnostics`