### PR TITLE
locationStrategy: 'path' deeplinks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -49,3 +49,4 @@ bin/ion-dev.css
 
 # WebStorm
 .idea
+/.vs

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,13 @@
+<a name="3.2.5"></a>
+## [3.2.5](https://github.com/ionic-team/ionic-app-scripts/compare/v3.2.4...v3.2.5) (2020-01-20)
+
+
+### Bug Fixes
+
+*  **serve:** enable 404 redirects to allow `locationStrategy: 'path'` to work with deeplinks  ([#10565](https://github.com/ionic-team/ionic/issues/10565#issuecomment-307420460))
+
+
+
 <a name="3.2.4"></a>
 ## [3.2.4](https://github.com/ionic-team/ionic-app-scripts/compare/v3.2.3...v3.2.4) (2019-05-24)
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ionic/app-scripts",
-  "version": "3.2.4",
+  "version": "3.2.5",
   "description": "Scripts for Ionic Projects",
   "homepage": "https://ionicframework.com/",
   "author": "Ionic Team <hi@ionic.io> (https://ionic.io)",

--- a/src/dev-server/http-server.ts
+++ b/src/dev-server/http-server.ts
@@ -47,6 +47,8 @@ export function createHttpServer(config: ServeConfig): express.Application {
     setupProxies(app);
   }
 
+  app.all('/*', serveIndex);
+
   return app;
 }
 


### PR DESCRIPTION
#### Short description of what this resolves:
enable 404 redirects in http-server.ts to allow `locationStrategy: 'path'` to work with deeplinks when running `ionic:serve` per https://github.com/ionic-team/ionic/issues/10565#issuecomment-307420460

#### Changes proposed in this pull request:

- http-server.ts wildcard handling of all sub-directories to point to index.html
- increment app-scripts version number to 3.2.5
- update CHANGELOG.md release description

**Fixes**: #
"Cannot GET /[deeplink-path]" no longer occurs and redirects work not using hash navigation